### PR TITLE
added trim()

### DIFF
--- a/jquery.translate.js
+++ b/jquery.translate.js
@@ -70,6 +70,7 @@
       var trn_key = $this.attr("data-trn-key");
       if (!trn_key) {
         trn_key = $this.html();
+        trn_key = trn_key.trim();
         $this.attr("data-trn-key", trn_key);   //store key for next time
       }
 


### PR DESCRIPTION
removes whitespace before and after the string so line breaks in the HTML will now work.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/Trim